### PR TITLE
Added missing dependancy on igbinary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
+        "ext-igbinary": "*",
         "symfony/framework-bundle": "^7.2",
         "symfony/messenger": "^7.2",
         "basis-company/nats": "^1",


### PR DESCRIPTION
This pull request introduces a minor dependency update to the project's PHP configuration. The change adds a new required extension to the `composer.json` file.

* Added `ext-igbinary` as a required PHP extension in `composer.json`, ensuring that the project will not install unless this extension is present.