### PR TITLE
Improved stream configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ framework:
           stream_max_bytes: 1073741824      # Max storage size in bytes (null = unlimited)
           stream_max_messages: 1000000      # Max number of messages (null = unlimited)
 
+          # Storage Backend
+          stream_storage: 'file'            # Storage type: 'file' or 'memory' (default: 'file')
+
           # High Availability
           stream_replicas: 1                # Number of replicas (default: 1)
 ```

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ framework:
           # Stream Retention Policies
           stream_max_age: 86400             # Max message age in seconds (0 = unlimited, default: 0)
           stream_max_bytes: 1073741824      # Max storage size in bytes (null = unlimited)
-          stream_max_messages: 1000000      # Max number of messages (null = unlimited)
+          stream_max_messages: 1000000      # Max number of messages per subject (null = unlimited)
 
           # Storage Backend
           stream_storage: 'file'            # Storage type: 'file' or 'memory' (default: 'file')
@@ -502,6 +502,35 @@ framework:
           stream_max_age: 2592000  # 30 days
           stream_replicas: 3
 ```
+
+### Multi-Subject Streams
+
+Multiple transports can share the same NATS stream with different subjects. When `messenger:setup-transports` runs, each transport adds its subject to the existing stream rather than overwriting it:
+
+```yaml
+framework:
+  messenger:
+    transports:
+      # Both transports share the "events" stream
+      nats_orders:
+        dsn: 'nats-jetstream://localhost/events/orders'
+        options:
+          consumer: 'order-consumer'
+          delay: 0.5
+          batching: 1
+          stream_max_age: 300
+
+      nats_payments:
+        dsn: 'nats-jetstream://localhost/events/payments'
+        options:
+          consumer: 'payment-consumer'
+          delay: 1
+          batching: 2
+```
+
+The `events` stream will have both `orders` and `payments` as subjects.
+
+> **Note:** Stream-level settings (prefixed with `stream_`) are applied when the stream is first created, and then for each additional subject on the same stream, **overwriting** any previous values. When defining multiple subjects per stream, it is recommended to only specify them in the first transport block.
 
 ### Setup on Initialization
 

--- a/src/NatsTransport.php
+++ b/src/NatsTransport.php
@@ -80,6 +80,8 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
         'stream_max_messages' => null,
         // Number of stream replicas for high availability
         'stream_replicas' => 1,
+        // Storage backend: 'file' or 'memory'
+        'stream_storage' => 'file',
     ];
 
     /**
@@ -461,6 +463,11 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
             // Apply replication factor for high availability
             if (isset($this->configuration['stream_replicas']) && $this->configuration['stream_replicas'] > 0) {
                 $streamConfig->setReplicas($this->configuration['stream_replicas']);
+            }
+
+            // Apply storage backend (file or memory)
+            if (isset($this->configuration['stream_storage'])) {
+                $streamConfig->setStorageBackend($this->configuration['stream_storage']);
             }
 
             // Create the stream with the configured settings

--- a/src/NatsTransport.php
+++ b/src/NatsTransport.php
@@ -483,7 +483,6 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
             }
 
             // Apply storage backend (file or memory)
-            // Important: Updating the storage backend for already existing streams is not allowed
             if (!$streamExists && isset($this->configuration['stream_storage'])) {
                 $streamConfig->setStorageBackend($this->configuration['stream_storage']);
             }

--- a/src/NatsTransport.php
+++ b/src/NatsTransport.php
@@ -448,14 +448,19 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
             $streamExists = $stream->exists();
 
             if ($streamExists) {
-                // Fetch stream subjects directly from the NATS server since getStream()
-                // returns a fresh Configuration object with an empty subjects array
+                // getStream() returns a fresh Configuration with defaults, not the
+                // actual server state. Hydrate from info() so that immutable fields
+                // like storage backend are correct before we call update().
                 $info = $this->decodeJsonInfo($stream->info());
-                $subjects = $info->config->subjects ?? [];
+                $serverConfig = (array) $info->config;
+                $streamConfig->fromArray($serverConfig);
+
+                // Merge the new subject into the existing subjects
+                $subjects = $serverConfig['subjects'] ?? [];
                 if (!in_array($this->topic, $subjects, true)) {
                     $subjects[] = $this->topic;
+                    $streamConfig->setSubjects($subjects);
                 }
-                $streamConfig->setSubjects($subjects);
             } else {
                 // Set the current topic on new streams
                 $streamConfig->setSubjects([$this->topic]);

--- a/src/NatsTransport.php
+++ b/src/NatsTransport.php
@@ -455,6 +455,19 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
                 $serverConfig = (array) $info->config;
                 $streamConfig->fromArray($serverConfig);
 
+                // Workaround: fromArray() in the vendor library does not hydrate
+                // all fields. Manually restore the ones we expose via configuration
+                // so that update() does not reset them to defaults.
+                if (isset($serverConfig['max_age'])) {
+                    $streamConfig->setMaxAge((int) $serverConfig['max_age']);
+                }
+                if (isset($serverConfig['max_bytes']) && $serverConfig['max_bytes'] !== null) {
+                    $streamConfig->setMaxBytes((int) $serverConfig['max_bytes']);
+                }
+                if (isset($serverConfig['max_msgs_per_subject']) && $serverConfig['max_msgs_per_subject'] !== null) {
+                    $streamConfig->setMaxMessagesPerSubject((int) $serverConfig['max_msgs_per_subject']);
+                }
+
                 // Merge the new subject into the existing subjects
                 $subjects = $serverConfig['subjects'] ?? [];
                 if (!in_array($this->topic, $subjects, true)) {
@@ -475,6 +488,11 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
             // Apply retention policy: max storage size in bytes
             if (isset($this->configuration['stream_max_bytes']) && $this->configuration['stream_max_bytes'] !== null) {
                 $streamConfig->setMaxBytes($this->configuration['stream_max_bytes']);
+            }
+
+            // Apply retention policy: max number of messages per subject
+            if (isset($this->configuration['stream_max_messages']) && $this->configuration['stream_max_messages'] !== null) {
+                $streamConfig->setMaxMessagesPerSubject(intval($this->configuration['stream_max_messages']));
             }
 
             // Apply replication factor for high availability

--- a/src/NatsTransport.php
+++ b/src/NatsTransport.php
@@ -443,9 +443,21 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
 
             // Retrieve the stream configuration for modification
             $streamConfig = $stream->getConfiguration();
+            $streamExists = $stream->exists();
 
-            // Configure the stream to listen to the topic/subject
-            $streamConfig->setSubjects([$this->topic]);
+            if ($streamExists) {
+                // Fetch stream subjects directly from the NATS server since getStream()
+                // returns a fresh Configuration object with an empty subjects array
+                $info = $this->decodeJsonInfo($stream->info());
+                $subjects = $info->config->subjects ?? [];
+                if (!in_array($this->topic, $subjects, true)) {
+                    $subjects[] = $this->topic;
+                }
+                $streamConfig->setSubjects($subjects);
+            } else {
+                // Set the current topic on new streams
+                $streamConfig->setSubjects([$this->topic]);
+            }
 
             // Apply retention policy: max age (convert seconds to nanoseconds)
             if (isset($this->configuration['stream_max_age']) && $this->configuration['stream_max_age'] > 0) {
@@ -463,8 +475,11 @@ class NatsTransport implements TransportInterface, MessageCountAwareInterface, S
                 $streamConfig->setReplicas($this->configuration['stream_replicas']);
             }
 
-            // Create the stream with the configured settings
-            $stream->create();
+            if ($streamExists) {
+                $stream->update();
+            } else {
+                $stream->create();
+            }
             $this->stream = $stream;
 
             // Create the consumer for message consumption

--- a/tests/unit/NatsTransportTest.php
+++ b/tests/unit/NatsTransportTest.php
@@ -1415,6 +1415,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
 
         // Create a mock API
         $mockApi = $this->createMock(\Basis\Nats\Api::class);
@@ -1456,6 +1459,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
         $mockStream->expects($this->once())
                   ->method('create')
                   ->willThrowException(new \Exception('Stream creation failed'));
@@ -1500,6 +1506,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
         $mockStream->expects($this->once())->method('create');
         $mockStream->expects($this->once())
                   ->method('getConsumer')
@@ -1560,6 +1569,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
         $mockStream->expects($this->once())->method('create');
         $mockStream->expects($this->once())
                   ->method('getConsumer')
@@ -1618,6 +1630,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
         $mockStream->expects($this->once())->method('create');
         $mockStream->expects($this->once())
                   ->method('getConsumer')
@@ -1679,6 +1694,9 @@ class NatsTransportTest extends TestCase
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
                   ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
         $mockStream->expects($this->once())->method('create');
         $mockStream->expects($this->once())
                   ->method('getConsumer')
@@ -1708,6 +1726,222 @@ class NatsTransportTest extends TestCase
         $this->expectExceptionMessage("Consumer was not created successfully");
 
         $transport->setup();
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithExistingStream_MergesNewSubject(): void
+    {
+        $dsn = self::VALID_DSN;
+        $transport = new NatsTransport($dsn, []);
+
+        // Create mock consumer configuration
+        $mockConsumerConfig = $this->createMock(\Basis\Nats\Consumer\Configuration::class);
+        $mockConsumerConfig->expects($this->any())->method('setAckPolicy');
+        $mockConsumerConfig->expects($this->any())->method('setDeliverPolicy');
+
+        // Create a mock consumer
+        $mockConsumer = $this->createMock(\Basis\Nats\Consumer\Consumer::class);
+        $mockConsumer->expects($this->any())
+                    ->method('getConfiguration')
+                    ->willReturn($mockConsumerConfig);
+        $mockConsumer->expects($this->once())->method('setBatching');
+        $mockConsumer->expects($this->once())->method('create');
+
+        // Create a mock configuration
+        $mockConfig = $this->createMock(\Basis\Nats\Stream\Configuration::class);
+        $mockConfig->expects($this->once())
+                  ->method('setSubjects')
+                  ->with(['existing-topic', 'test-topic']);
+
+        // Mock info() response with existing subjects from the server
+        $infoResponse = new \stdClass();
+        $infoResponse->body = json_encode((object) [
+            'config' => (object) ['subjects' => ['existing-topic']],
+        ]);
+
+        // Create a mock stream that already exists
+        $mockStream = $this->createMock(\Basis\Nats\Stream\Stream::class);
+        $mockStream->expects($this->once())
+                  ->method('getConfiguration')
+                  ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(true);
+        $mockStream->expects($this->once())
+                  ->method('info')
+                  ->willReturn($infoResponse);
+        $mockStream->expects($this->never())->method('create');
+        $mockStream->expects($this->once())->method('update');
+        $mockStream->expects($this->once())
+                  ->method('getConsumer')
+                  ->willReturn($mockConsumer);
+        $mockStream->expects($this->once())
+                  ->method('getConsumerNames')
+                  ->willReturn(['client']);
+
+        // Create a mock API
+        $mockApi = $this->createMock(\Basis\Nats\Api::class);
+        $mockApi->expects($this->once())
+               ->method('getStream')
+               ->willReturn($mockStream);
+
+        // Create a mock client
+        $mockClient = $this->createMock(\Basis\Nats\Client::class);
+        $mockClient->expects($this->once())
+                  ->method('getApi')
+                  ->willReturn($mockApi);
+
+        // Use reflection to inject the mock client
+        $reflection = new \ReflectionClass($transport);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($transport, $mockClient);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithExistingStreamAndDuplicateSubject_DoesNotAddDuplicate(): void
+    {
+        $dsn = self::VALID_DSN;
+        $transport = new NatsTransport($dsn, []);
+
+        // Create mock consumer configuration
+        $mockConsumerConfig = $this->createMock(\Basis\Nats\Consumer\Configuration::class);
+        $mockConsumerConfig->expects($this->any())->method('setAckPolicy');
+        $mockConsumerConfig->expects($this->any())->method('setDeliverPolicy');
+
+        // Create a mock consumer
+        $mockConsumer = $this->createMock(\Basis\Nats\Consumer\Consumer::class);
+        $mockConsumer->expects($this->any())
+                    ->method('getConfiguration')
+                    ->willReturn($mockConsumerConfig);
+        $mockConsumer->expects($this->once())->method('setBatching');
+        $mockConsumer->expects($this->once())->method('create');
+
+        // Create a mock configuration - setSubjects is still called with existing subjects
+        $mockConfig = $this->createMock(\Basis\Nats\Stream\Configuration::class);
+        $mockConfig->expects($this->once())
+                  ->method('setSubjects')
+                  ->with(['test-topic', 'other-topic']);
+
+        // Mock info() response where test-topic already exists
+        $infoResponse = new \stdClass();
+        $infoResponse->body = json_encode((object) [
+            'config' => (object) ['subjects' => ['test-topic', 'other-topic']],
+        ]);
+
+        // Create a mock stream that already exists
+        $mockStream = $this->createMock(\Basis\Nats\Stream\Stream::class);
+        $mockStream->expects($this->once())
+                  ->method('getConfiguration')
+                  ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(true);
+        $mockStream->expects($this->once())
+                  ->method('info')
+                  ->willReturn($infoResponse);
+        $mockStream->expects($this->never())->method('create');
+        $mockStream->expects($this->once())->method('update');
+        $mockStream->expects($this->once())
+                  ->method('getConsumer')
+                  ->willReturn($mockConsumer);
+        $mockStream->expects($this->once())
+                  ->method('getConsumerNames')
+                  ->willReturn(['client']);
+
+        // Create a mock API
+        $mockApi = $this->createMock(\Basis\Nats\Api::class);
+        $mockApi->expects($this->once())
+               ->method('getStream')
+               ->willReturn($mockStream);
+
+        // Create a mock client
+        $mockClient = $this->createMock(\Basis\Nats\Client::class);
+        $mockClient->expects($this->once())
+                  ->method('getApi')
+                  ->willReturn($mockApi);
+
+        // Use reflection to inject the mock client
+        $reflection = new \ReflectionClass($transport);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($transport, $mockClient);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithNewStream_CallsCreateNotUpdate(): void
+    {
+        $dsn = self::VALID_DSN;
+        $transport = new NatsTransport($dsn, []);
+
+        // Create mock consumer configuration
+        $mockConsumerConfig = $this->createMock(\Basis\Nats\Consumer\Configuration::class);
+        $mockConsumerConfig->expects($this->any())->method('setAckPolicy');
+        $mockConsumerConfig->expects($this->any())->method('setDeliverPolicy');
+
+        // Create a mock consumer
+        $mockConsumer = $this->createMock(\Basis\Nats\Consumer\Consumer::class);
+        $mockConsumer->expects($this->any())
+                    ->method('getConfiguration')
+                    ->willReturn($mockConsumerConfig);
+        $mockConsumer->expects($this->once())->method('setBatching');
+        $mockConsumer->expects($this->once())->method('create');
+
+        // Create a mock configuration
+        $mockConfig = $this->createMock(\Basis\Nats\Stream\Configuration::class);
+        $mockConfig->expects($this->once())
+                  ->method('setSubjects')
+                  ->with(['test-topic']);
+
+        // Create a mock stream that does not exist yet
+        $mockStream = $this->createMock(\Basis\Nats\Stream\Stream::class);
+        $mockStream->expects($this->once())
+                  ->method('getConfiguration')
+                  ->willReturn($mockConfig);
+        $mockStream->expects($this->once())
+                  ->method('exists')
+                  ->willReturn(false);
+        $mockStream->expects($this->once())->method('create');
+        $mockStream->expects($this->never())->method('update');
+        $mockStream->expects($this->once())
+                  ->method('getConsumer')
+                  ->willReturn($mockConsumer);
+        $mockStream->expects($this->once())
+                  ->method('getConsumerNames')
+                  ->willReturn(['client']);
+
+        // Create a mock API
+        $mockApi = $this->createMock(\Basis\Nats\Api::class);
+        $mockApi->expects($this->once())
+               ->method('getStream')
+               ->willReturn($mockStream);
+
+        // Create a mock client
+        $mockClient = $this->createMock(\Basis\Nats\Client::class);
+        $mockClient->expects($this->once())
+                  ->method('getApi')
+                  ->willReturn($mockApi);
+
+        // Use reflection to inject the mock client
+        $reflection = new \ReflectionClass($transport);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($transport, $mockClient);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/NatsTransportTest.php
+++ b/tests/unit/NatsTransportTest.php
@@ -1815,23 +1815,27 @@ class NatsTransportTest extends TestCase
         $mockConsumer->expects($this->once())->method('setBatching');
         $mockConsumer->expects($this->once())->method('create');
 
-        // Create a mock configuration
-        $mockConfig = $this->createMock(\Basis\Nats\Stream\Configuration::class);
-        $mockConfig->expects($this->once())
-                  ->method('setSubjects')
-                  ->with(['existing-topic', 'test-topic']);
+        // Create a real Configuration object so fromArray() works correctly
+        $streamConfig = new \Basis\Nats\Stream\Configuration('test-stream');
 
-        // Mock info() response with existing subjects from the server
+        // Mock info() response with full server config
         $infoResponse = new \stdClass();
         $infoResponse->body = json_encode((object) [
-            'config' => (object) ['subjects' => ['existing-topic']],
+            'config' => (object) [
+                'subjects' => ['existing-topic'],
+                'discard' => 'old',
+                'max_consumers' => -1,
+                'num_replicas' => 1,
+                'retention' => 'limits',
+                'storage' => 'memory',
+            ],
         ]);
 
         // Create a mock stream that already exists
         $mockStream = $this->createMock(\Basis\Nats\Stream\Stream::class);
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
-                  ->willReturn($mockConfig);
+                  ->willReturn($streamConfig);
         $mockStream->expects($this->once())
                   ->method('exists')
                   ->willReturn(true);
@@ -1866,7 +1870,9 @@ class NatsTransportTest extends TestCase
 
         $transport->setup();
 
-        $this->assertTrue(true);
+        // Verify subjects were merged and storage was preserved from server
+        $this->assertSame(['existing-topic', 'test-topic'], $streamConfig->getSubjects());
+        $this->assertSame('memory', $streamConfig->getStorageBackend());
     }
 
     /**
@@ -1890,23 +1896,27 @@ class NatsTransportTest extends TestCase
         $mockConsumer->expects($this->once())->method('setBatching');
         $mockConsumer->expects($this->once())->method('create');
 
-        // Create a mock configuration - setSubjects is still called with existing subjects
-        $mockConfig = $this->createMock(\Basis\Nats\Stream\Configuration::class);
-        $mockConfig->expects($this->once())
-                  ->method('setSubjects')
-                  ->with(['test-topic', 'other-topic']);
+        // Create a real Configuration object so fromArray() works correctly
+        $streamConfig = new \Basis\Nats\Stream\Configuration('test-stream');
 
         // Mock info() response where test-topic already exists
         $infoResponse = new \stdClass();
         $infoResponse->body = json_encode((object) [
-            'config' => (object) ['subjects' => ['test-topic', 'other-topic']],
+            'config' => (object) [
+                'subjects' => ['test-topic', 'other-topic'],
+                'discard' => 'old',
+                'max_consumers' => -1,
+                'num_replicas' => 1,
+                'retention' => 'limits',
+                'storage' => 'file',
+            ],
         ]);
 
         // Create a mock stream that already exists
         $mockStream = $this->createMock(\Basis\Nats\Stream\Stream::class);
         $mockStream->expects($this->once())
                   ->method('getConfiguration')
-                  ->willReturn($mockConfig);
+                  ->willReturn($streamConfig);
         $mockStream->expects($this->once())
                   ->method('exists')
                   ->willReturn(true);
@@ -1941,7 +1951,8 @@ class NatsTransportTest extends TestCase
 
         $transport->setup();
 
-        $this->assertTrue(true);
+        // Subjects should remain unchanged since test-topic already exists
+        $this->assertSame(['test-topic', 'other-topic'], $streamConfig->getSubjects());
     }
 
     /**

--- a/tests/unit/NatsTransportTest.php
+++ b/tests/unit/NatsTransportTest.php
@@ -1269,6 +1269,20 @@ class NatsTransportTest extends TestCase
     /**
      * @test
      */
+    public function setup_WithStreamMaxMessagesConfiguration_AppliesMaxMessages(): void
+    {
+        $dsn = 'nats://admin:password@localhost:4222/test-stream-max-msgs/max-msgs-topic';
+        $options = ['stream_max_messages' => 10000];
+        $transport = new NatsTransport($dsn, $options);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
     public function setup_WithStorageViaDsnQueryParam_AppliesStorage(): void
     {
         $dsn = 'nats://admin:password@localhost:4222/test-stream-dsn-storage/dsn-storage-topic?stream_storage=memory';
@@ -1828,6 +1842,9 @@ class NatsTransportTest extends TestCase
                 'num_replicas' => 1,
                 'retention' => 'limits',
                 'storage' => 'memory',
+                'max_age' => 3600000000000,
+                'max_bytes' => 1048576,
+                'max_msgs_per_subject' => 5000,
             ],
         ]);
 
@@ -1870,9 +1887,12 @@ class NatsTransportTest extends TestCase
 
         $transport->setup();
 
-        // Verify subjects were merged and storage was preserved from server
+        // Verify subjects were merged and server config was preserved
         $this->assertSame(['existing-topic', 'test-topic'], $streamConfig->getSubjects());
         $this->assertSame('memory', $streamConfig->getStorageBackend());
+        $this->assertSame(3600000000000, $streamConfig->getMaxAge());
+        $this->assertSame(1048576, $streamConfig->getMaxBytes());
+        $this->assertSame(5000, $streamConfig->getMaxMessagesPerSubject());
     }
 
     /**

--- a/tests/unit/NatsTransportTest.php
+++ b/tests/unit/NatsTransportTest.php
@@ -86,6 +86,7 @@ class TestableNatsTransport extends NatsTransport
             'stream_max_bytes' => null,
             'stream_max_messages' => null,
             'stream_replicas' => 1,
+            'stream_storage' => 'file',
         ];
         $configuration = [];
         $configuration += $options + $query + $defaultOptions;
@@ -1235,6 +1236,71 @@ class NatsTransportTest extends TestCase
 
         // If no exception thrown, setup was successful
         $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithMemoryStorageConfiguration_AppliesMemoryStorage(): void
+    {
+        $dsn = 'nats://admin:password@localhost:4222/test-stream-memory/memory-topic';
+        $options = ['stream_storage' => 'memory'];
+        $transport = new NatsTransport($dsn, $options);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithFileStorageConfiguration_AppliesFileStorage(): void
+    {
+        $dsn = 'nats://admin:password@localhost:4222/test-stream-file-storage/file-topic';
+        $options = ['stream_storage' => 'file'];
+        $transport = new NatsTransport($dsn, $options);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function setup_WithStorageViaDsnQueryParam_AppliesStorage(): void
+    {
+        $dsn = 'nats://admin:password@localhost:4222/test-stream-dsn-storage/dsn-storage-topic?stream_storage=memory';
+        $transport = new NatsTransport($dsn, []);
+
+        $transport->setup();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function constructor_WithStorageOption_StoresInConfiguration(): void
+    {
+        $dsn = self::VALID_DSN;
+        $transport = new TestableNatsTransport($dsn, ['stream_storage' => 'memory']);
+
+        $config = $transport->getTestConfiguration();
+        $this->assertSame('memory', $config['stream_storage']);
+    }
+
+    /**
+     * @test
+     */
+    public function constructor_WithDefaultStorage_DefaultsToFile(): void
+    {
+        $dsn = self::VALID_DSN;
+        $transport = new TestableNatsTransport($dsn, []);
+
+        $config = $transport->getTestConfiguration();
+        $this->assertSame('file', $config['stream_storage']);
     }
 
     /**


### PR DESCRIPTION
This pull request improves a few details regarding stream declaration, and fixes a bug in the current version:

**Fix `stream_max_messages`**

This configuration parameter didn't work yet, the stream was always initialized with the default value. This is fixed now, I've also updated the documentation to clarify that the parameter affects the max. messages per subject (`max_msgs_per_subject`) in contrary to max. messages per stream.

**Allow setting the storage type of a stream**

It is now possible to set the storage type of a stream (`file` or `memory`) upon creation. The caveat here is that this setting can not be altered for existing streams, and any attempt to do so would result in an error. Hence, its silently ignored for existing streams.

**Allow multiple subjects per stream**

Due to the way streams were initialized, it was not possible to create multiple subjects for the same stream, a pattern commonly used to logically group or namespace message queues.

I have refactored how streams are created to allow something like the following example:
```yaml
framework:
  messenger:
    transports:
      nats_orders:
        dsn: 'nats-jetstream://localhost/events/orders'
        options:
          consumer: 'order-consumer'
          delay: 0.5
          batching: 1
          stream_max_age: 300

      nats_payments:
        dsn: 'nats-jetstream://localhost/events/payments'
        options:
          consumer: 'payment-consumer'
          delay: 1
          batching: 2
```

---

Please let me know if there's any feedback or things you would like me to change.